### PR TITLE
Turn all AST interpretation functions into generator functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # ClaveScript
-ClaveScript - a browser-based environment for live-coding music
+
+A browser-based environment for live-coding music.
 
 # Development
+
+ClaveScript is in early stages of development. The goal is to create a simple
+programming language for controlling WebAudio synths and external synthesizers
+through Web MIDI. It does not build static representations of music but
+evaluates programs (possibly multiple threads of execution) in real time so
+that programs can react to external input (i.e. MIDI controllers) with little
+delay.
 
 Developed with Node.js version 14.5.0

--- a/src/interpreter/evaluator.ts
+++ b/src/interpreter/evaluator.ts
@@ -183,24 +183,16 @@ export const createEvaluator: (
 
   // eslint-disable-next-line require-yield
   function* evaluatePlay(ctx: Context, stmt: BuiltInCommand): EventGen<void> {
-    // if (stmt.arg.type !== 'integer') throw Error('Must be an integer');
-
-    const pitch = (() => {
-      if (stmt.arg.type === 'identifier') {
-        return evaluateIdentifierAsInteger(ctx, stmt.arg);
-      } else if (stmt.arg.type === 'integer') {
-        return stmt.arg.value;
-      } else {
-        throw Error('Must be an integer');
-      }
-    })();
+    const pitch = yield* evaluateExpression(ctx, stmt.arg);
+    if (pitch.type !== 'number')
+      throw Error('Play only accepts a number as argument');
 
     ctx.seq.push({
       type: 'NOTE',
       startTime: ctx.playheadPosition,
       duration: 0.25,
       volume: 64,
-      pitch: pitch,
+      pitch: pitch.value,
       instrument: 'audio',
     });
     ctx.seq.push({
@@ -208,7 +200,7 @@ export const createEvaluator: (
       startTime: ctx.playheadPosition,
       duration: 0.25,
       volume: 64,
-      pitch: pitch,
+      pitch: pitch.value,
       instrument: 'midi',
     });
   }

--- a/src/interpreter/evaluator.ts
+++ b/src/interpreter/evaluator.ts
@@ -213,7 +213,6 @@ export const createEvaluator: (
     }
   }
 
-  // eslint-disable-next-line require-yield
   function* evaluateFunctionCall(
     ctx: Context,
     stmt: FunctionCall

--- a/src/interpreter/evaluator.ts
+++ b/src/interpreter/evaluator.ts
@@ -206,15 +206,12 @@ export const createEvaluator: (
   }
 
   function* evaluateSleep(ctx: Context, stmt: BuiltInCommand): EventGen<void> {
-    ctx.playheadPosition += (() => {
-      if (stmt.arg.type === 'identifier') {
-        return evaluateIdentifierAsInteger(ctx, stmt.arg);
-      } else if (stmt.arg.type === 'float' || stmt.arg.type === 'integer') {
-        return stmt.arg.value;
-      } else {
-        throw Error('Must be an integer or a float');
-      }
-    })();
+    const arg = yield* evaluateExpression(ctx, stmt.arg);
+
+    if (arg.type !== 'number')
+      throw Error('Sleep command only accepts numbers');
+
+    ctx.playheadPosition += arg.value;
 
     while (ctx.playheadPosition > ctx.playUntil) {
       ctx.playUntil = yield {

--- a/src/interpreter/parser.ts
+++ b/src/interpreter/parser.ts
@@ -55,7 +55,7 @@ export type MusicalProcedure = {
 export type BuiltInCommand = {
   type: 'cmd';
   name: CommandString;
-  arg: MusicalExpression | Identifier | Integer | Float;
+  arg: Expression;
 };
 
 export type FunctionDefinition = {
@@ -289,24 +289,6 @@ export const parse: (tokenizer: Tokenizer) => Block = tokenizer => {
     };
   };
 
-  const parseBuiltInCommandArg: () =>
-    | MusicalExpression
-    | Identifier
-    | Integer
-    | Float = () => {
-    const token = tokenizer.peek();
-    switch (token.type) {
-      case TokenType.Identifier:
-        return parseIdentifier();
-      case TokenType.Integer:
-        return parseInteger();
-      case TokenType.Float:
-        return parseFloat();
-      default:
-        throw Error('Unable to parse the build in command argument');
-    }
-  };
-
   // TODO: make this specific to the built-in command
   const parseBuiltInCommand: () => BuiltInCommand = () => {
     const token = tokenizer.next();
@@ -326,7 +308,7 @@ export const parse: (tokenizer: Tokenizer) => Block = tokenizer => {
     return {
       type: 'cmd',
       name: token.value,
-      arg: parseBuiltInCommandArg(),
+      arg: parseExpression(),
     };
   };
 


### PR DESCRIPTION
Turn all AST walk functions into generator functions so that the threads (implemented as coroutines) can be run by the sequencer concurrently.

Various parser and interpreter enhancements.

Updated README to show the project goal.