### PR TITLE
Abort "threads" if slow computations are detected

### DIFF
--- a/src/music/sequencer.ts
+++ b/src/music/sequencer.ts
@@ -2,6 +2,8 @@ import {AudioManager} from './audio';
 import {NoteRef, ReadOnlyInstrumentLibrary} from './instrument';
 import {Logger} from '../logger';
 
+export const LOOKAHEAD_TIME = 100; // ms
+
 export type MusicalEvent = Note | PitchBend;
 
 export type Note = {
@@ -202,7 +204,6 @@ export const createSequencer: (
   logger: Logger
 ) => Sequencer = (audio, instruments, logger) => {
   const SCHEDULER_INTERVAL = 25; // ms
-  const LOOKAHEAD_TIME = 100; // ms
 
   let beatsPerMinute = 120; // Beats (quarter notes) per minute
   let isPlaying = false;


### PR DESCRIPTION
Because code is currently interpreted in the UI thread, the whole UI
freezes if there are slow computations, e.g. the user accidentally
writes an infinite loop without a call to 'sleep'. To prevent this, I
Introduced a simple detection of slow computations.

The "threads" are aborted by raising an exception if the duration of the
computation is nearing the "look-ahead time" of the sequencer. Such
computations would in any case cause the music to start "stuttering". If
expensive calculation is required, one way to allow it is to increase
the lookahead time of the sequencer.