### PR TITLE
Variable declaration & lexical scope (closures)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,36 +20,37 @@ scales. It also includes a simple bass line.
 
     tempo 100;
 
-    base = 40;
-    major = [0, 2, 4, 5, 7, 9, 11];
-    harmonicMinor = [0, 2, 3, 5, 7, 8, 11];
+    let base = 40;
+    let major = [0, 2, 4, 5, 7, 9, 11];
+    let harmonicMinor = [0, 2, 3, 5, 7, 8, 11];
 
-    randomInteger = fun (maxVal) {
+    let randomInteger = fun (maxVal) {
       return floor(rand() * maxVal);
     };
 
-    craziness = fun() {
-      coinToss = randomInteger(2);
+    let craziness = fun() {
+      let coinToss = randomInteger(2);
+      let scale;
       if (coinToss == 1)
         scale = major;
       else
         scale = harmonicMinor;
 
-      for (i = 0; i < 32; i = i + 1) {
-        note = randomInteger(len(scale));
-        octave = randomInteger(3);
+      for (let i = 0; i < 32; i = i + 1) {
+        let note = randomInteger(len(scale));
+        let octave = randomInteger(3);
         play base + scale[note] + octave * 12;
         sleep 0.25;
       }
     };
 
-    melody = seq {
+    let melody = seq {
       craziness();
     };
 
     loop melody;
 
-    bass = seq {
+    let bass = seq {
       base = 40;
 
       play base;
@@ -67,7 +68,7 @@ step sequencers.
 
     tempo 100;
 
-    pattern =
+    let pattern =
       step { x - x - x - x - x - x - x - x - x - x - x - x - x - x - x - | x = 88 } :=:
       step { x - x - - x - x - - x - x - - x - x - - x - x - - x - x - - | x = 44 } :=:
       step { x - - - - x x - - - - x x - - - - x x - - - - x x - - - - x | x = 25 } :+:

--- a/dist/index.html
+++ b/dist/index.html
@@ -34,39 +34,38 @@
 
 tempo 100;
 
-base = 40;
-major = [0, 2, 4, 5, 7, 9, 11];
-harmonicMinor = [0, 2, 3, 5, 7, 8, 11];
+let base = 40;
+let major = [0, 2, 4, 5, 7, 9, 11];
+let harmonicMinor = [0, 2, 3, 5, 7, 8, 11];
 
-randomInteger = fun (maxVal) {
+let randomInteger = fun (maxVal) {
   return floor(rand() * maxVal);
 };
 
-craziness = fun() {
-  coinToss = randomInteger(2);
+let craziness = fun() {
+  let coinToss = randomInteger(2);
+  let scale;
   if (coinToss == 1)
     scale = major;
   else
     scale = harmonicMinor;
 
-  for (i = 0; i < 32; i = i + 1) {
-    note = randomInteger(len(scale));
-    octave = randomInteger(3);
+  for (let i = 0; i < 32; i = i + 1) {
+    let note = randomInteger(len(scale));
+    let octave = randomInteger(3);
     play base + scale[note] + octave * 12;
     sleep 0.25;
   }
 };
 
 
-melody = seq {
+let melody = seq {
   craziness();
 };
 
 loop melody;
 
-bass = seq {
-  base = 40;
-
+let bass = seq {
   play base;
   sleep 0.75;
   play base - 5;

--- a/dist/index.html
+++ b/dist/index.html
@@ -76,7 +76,7 @@ let bass = seq {
 
 loop bass;
 
-#pattern =
+#let pattern =
 #  step { x - x - x - x - x - x - x - x - x - x - x - x - x - x - x - | x = 88 } :=:
 #  step { x - x - - x - x - - x - x - - x - x - - x - x - - x - x - - | x = 44 } :=:
 #  step { x - - - - x x - - - - x x - - - - x x - - - - x x - - - - x | x = 25 } :+:

--- a/src/interpreter/evaluator.ts
+++ b/src/interpreter/evaluator.ts
@@ -46,7 +46,7 @@ type VariableMusicalEventSource = {
 type VariableFunctionDefinition = {
   type: 'fun';
   value: FunctionDefinition;
-  closure: Environment;
+  env: Environment;
 };
 type VariableBuiltInFunction = {
   type: 'internal';
@@ -69,7 +69,6 @@ export type VariableValue =
 
 export type Environment = {
   extend(): Environment;
-  copy(): Environment;
   getParent(): Environment | null;
   lookup(name: string): Environment | null;
   isInCurrentScope(name: string): boolean;
@@ -90,12 +89,6 @@ const createEnvironment: (
   const env = {
     extend(): Environment {
       return createEnvironment(env, Object.create(scope));
-    },
-
-    copy(): Environment {
-      const copiedScope = {...scope};
-      Object.setPrototypeOf(copiedScope, Object.getPrototypeOf(scope));
-      return createEnvironment(parent, copiedScope);
     },
 
     getParent(): Environment | null {
@@ -327,7 +320,7 @@ export const createEvaluator: (
       );
     }
 
-    const funEnv = func.closure.extend();
+    const funEnv = func.env.extend();
 
     for (let i = 0; i < expr.args.length; i++) {
       funEnv.def(
@@ -362,7 +355,7 @@ export const createEvaluator: (
     return {
       type: 'fun',
       value: stmt,
-      closure: ctx.env, //.copy(),
+      env: ctx.env,
     };
   }
 

--- a/src/interpreter/tokenizer.ts
+++ b/src/interpreter/tokenizer.ts
@@ -56,6 +56,7 @@ const keywordStrings = [
   'else',
   'while',
   'for',
+  'let',
   ...commandStrings,
 ] as const;
 export type KeywordString = typeof keywordStrings[number];


### PR DESCRIPTION
Introduce variable declaration with "let" keyword. I tried to get away without explicit variable declaration but it makes variable scopes hard to understand. (And I don't want something like "global" & "nonlocal" keywords in Python.)

I also finally added closures to achieve lexical scope. It's still a bit dynamic. For example, calling the following _bar_ function will first play 40 and then 80.  

    let a = 40;
    let bar = fun() {
      let foo = fun() {
        play a;
        sleep 1;
      };
      foo();
      let a = 80;
      foo();
    };

Also, variables can be re-declared in the same scope.

But this is okay for now. I intend to fix these later with some static analysis phase.