### PR TITLE
Support for specifying MIDI outputs and channels for instruments. Note type with velocity and duration.

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -22,6 +22,9 @@
             <li>
                 <button class="stop-button">Stop</button>
             </li>
+            <li class="midi-disabled-notice">
+                MIDI support disabled
+            </li>
             <li class="clear-log-item">
                 <button class="clear-log-button">Clear log</button>
             </li>

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -100,6 +100,13 @@ textarea#code:focus {
     margin-right: 1rem;
 }
 
+.toolbar li.midi-disabled-notice {
+    font-family: monospace;
+    color: #FF0028;
+    margin-left: auto; /* center */
+    display: none;
+}
+
 .toolbar li.clear-log-item {
     margin-left: auto; /* pull right */
     margin-right: 0;

--- a/src/interpreter/built-in-functions.ts
+++ b/src/interpreter/built-in-functions.ts
@@ -1,5 +1,6 @@
 import {Environment, VariableString, VariableValue} from './evaluator';
 import {Logger} from '../logger';
+import {getMidiAccess, isWebMIDISupported} from '../music/midi';
 
 export const initializeBuiltInFunctions: (
   globalEnv: Environment,
@@ -79,5 +80,28 @@ export const initializeBuiltInFunctions: (
     type: 'internal',
     name: 'str',
     value: convertToString,
+  });
+
+  globalEnv.set('list_midi_outputs', {
+    type: 'internal',
+    name: 'list_midi_outputs',
+    value: () => {
+      if (!isWebMIDISupported()) {
+        throw Error('Web MIDI API is not supported by the browser');
+      }
+
+      const midi = getMidiAccess();
+      const outputs: VariableString[] = Array.from(
+        midi.listOutputs().values()
+      ).map(o => ({
+        type: 'string',
+        value: o.name || 'undefined',
+      }));
+
+      return {
+        type: 'array',
+        items: outputs,
+      };
+    },
   });
 };

--- a/src/interpreter/built-in-functions.ts
+++ b/src/interpreter/built-in-functions.ts
@@ -55,6 +55,23 @@ export const initializeBuiltInFunctions: (
       return {type: 'string', value: val.value.toString(10)};
     if (val.type === 'boolean')
       return {type: 'string', value: val.value.toString()};
+    if (val.type === 'audio_instrument')
+      return {type: 'string', value: `audio_instrument(${val.id})`};
+    if (val.type === 'midi_instrument')
+      return {
+        type: 'string',
+        value: `midi_instrument(output="${val.output.name}",channel=${val.channel})`,
+      };
+    if (val.type === 'note')
+      return {
+        type: 'string',
+        value: `note(${
+          convertToString(val.instrument).value
+        },p=${val.pitch.toString(10)},v=${val.volume.toString(
+          10
+        )},d=${val.duration.toString(10)})`,
+      };
+
     if (val.type === 'array')
       return {
         type: 'string',
@@ -144,7 +161,41 @@ export const initializeBuiltInFunctions: (
       return {
         type: 'midi_instrument',
         output: output,
-        channel: 0,
+        channel: channel.value,
+      };
+    },
+  });
+
+  globalEnv.set('note', {
+    type: 'internal',
+    name: 'note',
+    value: (
+      instrument: VariableValue,
+      pitch: VariableValue,
+      volume: VariableValue,
+      duration: VariableValue
+    ) => {
+      if (
+        instrument.type !== 'midi_instrument' &&
+        instrument.type !== 'audio_instrument'
+      )
+        throw Error('Invalid instrument');
+
+      if (pitch.type !== 'number' || !Number.isInteger(pitch.value))
+        throw Error('Pitch must be an integer');
+
+      if (volume.type !== 'number' || !Number.isInteger(volume.value))
+        throw Error('Volume must be an integer');
+
+      if (duration.type !== 'number')
+        throw Error('Duration must be an integer');
+
+      return {
+        type: 'note',
+        instrument: instrument,
+        pitch: pitch.value,
+        volume: volume.value,
+        duration: duration.value,
       };
     },
   });

--- a/src/interpreter/built-in-functions.ts
+++ b/src/interpreter/built-in-functions.ts
@@ -146,10 +146,10 @@ export const initializeBuiltInFunctions: (
       if (
         channel.type !== 'number' ||
         !Number.isInteger(channel.value) ||
-        channel.value < 0 ||
-        channel.value > 15
+        channel.value < 1 ||
+        channel.value > 16
       ) {
-        throw Error('MIDI channel must be an integer between 0 - 15');
+        throw Error('MIDI channel must be an integer between 1 - 16');
       }
 
       const midi = getMidiAccess();
@@ -161,7 +161,7 @@ export const initializeBuiltInFunctions: (
       return {
         type: 'midi_instrument',
         output: output,
-        channel: channel.value,
+        channel: channel.value - 1,
       };
     },
   });
@@ -181,14 +181,24 @@ export const initializeBuiltInFunctions: (
       )
         throw Error('Invalid instrument');
 
-      if (pitch.type !== 'number' || !Number.isInteger(pitch.value))
-        throw Error('Pitch must be an integer');
+      if (
+        pitch.type !== 'number' ||
+        !Number.isInteger(pitch.value) ||
+        pitch.value < 0 ||
+        pitch.value > 127
+      )
+        throw Error('Pitch must be an integer in range 0 - 127');
 
-      if (volume.type !== 'number' || !Number.isInteger(volume.value))
-        throw Error('Volume must be an integer');
+      if (
+        volume.type !== 'number' ||
+        !Number.isInteger(volume.value) ||
+        pitch.value < 0 ||
+        pitch.value > 127
+      )
+        throw Error('Volume must be an integerin range 0 - 127');
 
-      if (duration.type !== 'number')
-        throw Error('Duration must be an integer');
+      if (duration.type !== 'number' || duration.value < 0)
+        throw Error('Duration must be an positive number');
 
       return {
         type: 'note',

--- a/src/interpreter/evaluator.ts
+++ b/src/interpreter/evaluator.ts
@@ -245,20 +245,19 @@ export const createEvaluator: (
     else throw Error('Identifier must be a sequence');
   };
 
-  // eslint-disable-next-line require-yield
   function* evaluatePlay(ctx: Context, stmt: BuiltInCommand): EventGen<void> {
     const pitch = yield* evaluateExpression(ctx, stmt.arg);
     if (pitch.type !== 'number')
       throw Error('Play only accepts a number as argument');
 
-    ctx.seq.push({
-      type: 'NOTE',
-      startTime: ctx.playheadPosition,
-      duration: 0.25,
-      volume: 64,
-      pitch: pitch.value,
-      instrument: 'audio',
-    });
+    // ctx.seq.push({
+    //   type: 'NOTE',
+    //   startTime: ctx.playheadPosition,
+    //   duration: 0.25,
+    //   volume: 64,
+    //   pitch: pitch.value,
+    //   instrument: 'audio',
+    // });
     ctx.seq.push({
       type: 'NOTE',
       startTime: ctx.playheadPosition,

--- a/src/interpreter/evaluator.ts
+++ b/src/interpreter/evaluator.ts
@@ -69,6 +69,13 @@ type VariableWebAudioInstrument = {
   type: 'audio_instrument';
   id: string;
 };
+export type VariableNote = {
+  type: 'note';
+  instrument: VariableInstrument;
+  pitch: number;
+  volume: number;
+  duration: number;
+};
 
 export type VariableValue =
   | VariableNumber
@@ -80,7 +87,8 @@ export type VariableValue =
   | VariableArray
   | VariableNil
   | VariableString
-  | VariableInstrument;
+  | VariableInstrument
+  | VariableNote;
 
 export type Environment = {
   extend(): Environment;

--- a/src/interpreter/evaluator.ts
+++ b/src/interpreter/evaluator.ts
@@ -56,9 +56,19 @@ type VariableBuiltInFunction = {
   value: (...args: VariableValue[]) => VariableValue;
 };
 type VariableBoolean = {type: 'boolean'; value: boolean};
-type VariableArray = {type: 'array'; items: VariableValue[]};
+export type VariableArray = {type: 'array'; items: VariableValue[]};
 type VariableNil = {type: 'nil'};
 export type VariableString = {type: 'string'; value: string};
+type VariableInstrument = VariableMidiInstrument | VariableWebAudioInstrument;
+type VariableMidiInstrument = {
+  type: 'midi_instrument';
+  output: WebMidi.MIDIOutput;
+  channel: number;
+};
+type VariableWebAudioInstrument = {
+  type: 'audio_instrument';
+  id: string;
+};
 
 export type VariableValue =
   | VariableNumber
@@ -69,7 +79,8 @@ export type VariableValue =
   | VariableBoolean
   | VariableArray
   | VariableNil
-  | VariableString;
+  | VariableString
+  | VariableInstrument;
 
 export type Environment = {
   extend(): Environment;

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import {createInstrumentLibrary} from './music/instrument';
 import {createSequencer, Sequencer} from './music/sequencer';
 import {createLogger, LogMessage, Logger} from './logger';
 import {
-  getMIDIAccess,
+  initMIDIAccess,
   DEFAULT_MIDI_OUTPUT_DEVICE_NAME,
   isWebMIDISupported,
 } from './music/midi';
@@ -48,7 +48,7 @@ const setupSequencer: (logger: Logger) => Promise<Sequencer> = async logger => {
   });
 
   if (isWebMIDISupported()) {
-    const midiAccess = await getMIDIAccess(() => audio.getCurrentTime());
+    const midiAccess = await initMIDIAccess(() => audio.getCurrentTime());
 
     const defaultMidiOutput = Array.from(
       midiAccess.listOutputs().values()

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,11 +6,7 @@ import {createAudioManager} from './music/audio';
 import {createInstrumentLibrary} from './music/instrument';
 import {createSequencer, Sequencer} from './music/sequencer';
 import {createLogger, LogMessage, Logger} from './logger';
-import {
-  initMIDIAccess,
-  DEFAULT_MIDI_OUTPUT_DEVICE_NAME,
-  isWebMIDISupported,
-} from './music/midi';
+import {initMIDIAccess, isWebMIDISupported} from './music/midi';
 
 const execute: (input: string, evaluator: Evaluator, log: Logger) => void = (
   input,
@@ -48,19 +44,7 @@ const setupSequencer: (logger: Logger) => Promise<Sequencer> = async logger => {
   });
 
   if (isWebMIDISupported()) {
-    const midiAccess = await initMIDIAccess(() => audio.getCurrentTime());
-
-    const defaultMidiOutput = Array.from(
-      midiAccess.listOutputs().values()
-    ).find(v => v.name === DEFAULT_MIDI_OUTPUT_DEVICE_NAME);
-
-    if (defaultMidiOutput) {
-      instruments.add('midi', {
-        playNote: (...args) => {
-          return midiAccess.playNote(defaultMidiOutput, ...args);
-        },
-      });
-    }
+    await initMIDIAccess(() => audio.getCurrentTime());
   }
 
   return createSequencer(audio, instruments, logger);

--- a/src/music/midi.ts
+++ b/src/music/midi.ts
@@ -19,7 +19,7 @@ export type MIDIAccess = {
 
 let midiAccess: MIDIAccess | null = null;
 
-export const getMIDIAccess: (
+export const initMIDIAccess: (
   getAudioContextTime: () => number
 ) => Promise<MIDIAccess> = async getAudioContextTime => {
   if (midiAccess) return midiAccess;
@@ -71,5 +71,12 @@ export const getMIDIAccess: (
     },
   };
 
+  return midiAccess;
+};
+
+export const getMidiAccess: () => MIDIAccess = () => {
+  if (!midiAccess) {
+    throw Error('MIDI access uninitialized');
+  }
   return midiAccess;
 };

--- a/src/music/midi.ts
+++ b/src/music/midi.ts
@@ -11,6 +11,7 @@ export type MIDIAccess = {
   listOutputs(): WebMidi.MIDIOutputMap;
   playNote(
     output: WebMidi.MIDIOutput,
+    channel: number,
     pitch: AbsPitch,
     velocity: number,
     time?: number
@@ -37,6 +38,7 @@ export const initMIDIAccess: (
 
     playNote(
       output: MIDIOutput,
+      channel: number,
       pitch: AbsPitch,
       velocity: number,
       time?: number
@@ -53,7 +55,7 @@ export const initMIDIAccess: (
 
       const startTime = calculateStartTime();
 
-      output.send([0x90, pitch, velocity], startTime);
+      output.send([0x90 | channel, pitch, velocity], startTime);
 
       return {
         stop: (time?: number) => {
@@ -61,7 +63,7 @@ export const initMIDIAccess: (
           const now = window.performance.now();
           const clockOffset = now - getAudioContextTime() * 1000;
           output.send(
-            [0x80, pitch, velocity],
+            [0x80 | channel, pitch, velocity],
             time === undefined
               ? startTime + stopOffset
               : time * 1000 + clockOffset

--- a/src/music/midi.ts
+++ b/src/music/midi.ts
@@ -2,70 +2,74 @@ import {AbsPitch} from './music';
 import {NoteRef} from './instrument';
 import MIDIOutput = WebMidi.MIDIOutput;
 
-// const MIDI_OUTPUT_DEVICE_NAME = 'MIDISPORT 2x2 Anniv A ';
-const MIDI_OUTPUT_DEVICE_NAME = 'IAC Driver Bus 1';
-
-// TODO: initialize this in a different scope
-let midiOutput: MIDIOutput;
-
-let getAudioContextTime: () => number = () => 0;
+// const DEFAULT_MIDI_OUTPUT_DEVICE_NAME = 'MIDISPORT 2x2 Anniv A ';
+export const DEFAULT_MIDI_OUTPUT_DEVICE_NAME = 'IAC Driver Bus 1';
 
 export const isWebMIDISupported = () => !!navigator.requestMIDIAccess;
 
-export const initializeMIDI: (
+export type MIDIAccess = {
+  listOutputs(): WebMidi.MIDIOutputMap;
+  playNote(
+    output: WebMidi.MIDIOutput,
+    pitch: AbsPitch,
+    velocity: number,
+    time?: number
+  ): NoteRef;
+};
+
+let midiAccess: MIDIAccess | null = null;
+
+export const getMIDIAccess: (
   getAudioContextTime: () => number
-) => void = async getAudioContextTimeFunc => {
-  getAudioContextTime = getAudioContextTimeFunc;
+) => Promise<MIDIAccess> = async getAudioContextTime => {
+  if (midiAccess) return midiAccess;
+
   if (!isWebMIDISupported()) {
     throw new Error('WebMIDI is not supported');
   }
 
   const access = await navigator.requestMIDIAccess(); // { sysex: true }
 
-  // access.inputs.forEach(i => {
-  //     if (i.name === MIDI_INPUT_DEVICE_NAME) {
-  //         console.log(`Setting onMIDIMessage callback for ${i.name}`);
-  //         i.onmidimessage = onMIDIMessage;
-  //     }
-  // });
+  midiAccess = {
+    listOutputs(): WebMidi.MIDIOutputMap {
+      return access.outputs;
+    },
 
-  access.outputs.forEach(o => {
-    console.log(o);
-    if (o.name === MIDI_OUTPUT_DEVICE_NAME) {
-      console.log(`setting ${MIDI_OUTPUT_DEVICE_NAME} as MIDI output device`);
-      midiOutput = o;
-    }
-  });
-};
+    playNote(
+      output: MIDIOutput,
+      pitch: AbsPitch,
+      velocity: number,
+      time?: number
+    ): NoteRef {
+      const calculateStartTime = () => {
+        const now = window.performance.now();
+        if (time === undefined) {
+          return now;
+        } else {
+          const clockOffset = now - getAudioContextTime() * 1000;
+          return time * 1000 + clockOffset;
+        }
+      };
 
-export const playMidiNote: (
-  pitch: AbsPitch,
-  velocity: number,
-  time?: number
-) => NoteRef = (pitch, velocity, time = undefined) => {
-  const calculateStartTime = () => {
-    const now = window.performance.now();
-    if (time === undefined) {
-      return now;
-    } else {
-      const clockOffset = now - getAudioContextTime() * 1000;
-      return time * 1000 + clockOffset;
-    }
-  };
+      const startTime = calculateStartTime();
 
-  const startTime = calculateStartTime();
+      output.send([0x90, pitch, velocity], startTime);
 
-  midiOutput.send([0x90, pitch, velocity], startTime);
-
-  return {
-    stop: (time?: number) => {
-      const stopOffset = 1; // millisecond, make sure that stop event always comes after start
-      const now = window.performance.now();
-      const clockOffset = now - getAudioContextTime() * 1000;
-      midiOutput.send(
-        [0x80, pitch, velocity],
-        time === undefined ? startTime + stopOffset : time * 1000 + clockOffset
-      );
+      return {
+        stop: (time?: number) => {
+          const stopOffset = 1; // millisecond, make sure that stop event always comes after start
+          const now = window.performance.now();
+          const clockOffset = now - getAudioContextTime() * 1000;
+          output.send(
+            [0x80, pitch, velocity],
+            time === undefined
+              ? startTime + stopOffset
+              : time * 1000 + clockOffset
+          );
+        },
+      };
     },
   };
+
+  return midiAccess;
 };

--- a/src/music/sequencer.ts
+++ b/src/music/sequencer.ts
@@ -221,6 +221,7 @@ export const createSequencer: (
         // TODO: Add channel to MIDI note playback
         return midiAccess.playNote(
           note.varNote.instrument.output,
+          note.varNote.instrument.channel,
           note.varNote.pitch,
           note.varNote.volume,
           absTime

--- a/src/music/sequencer.ts
+++ b/src/music/sequencer.ts
@@ -9,6 +9,7 @@ export type MusicalEvent = Note | PitchBend;
 export type Note = {
   type: 'NOTE';
   startTime: number; // 1 is one beat, i.e quarter note
+  // varNote: VariableNote;
   instrument: string;
   pitch: number; // absolute pitch 0 - 128
   duration: number; // 1 equals one beat, i.e quarter note


### PR DESCRIPTION
Print available MIDI outputs to console:
`print(list_midi_outputs());`

The output format is a list a list of (output_id, output_name) pairs:
`[["37366941", "IAC Driver Bus 1"]]`

Create MIDI instruments:

    let piano = create_midi_instrument("37366941", 1);
    let bass  = create_midi_instrument("37366941", 2);
    
Play back midi notes with instrument, pitch, velocity and duration like this:
`play note(piano, pitch, velocity, duration);`
